### PR TITLE
Feature/#92 prosper can crud on events

### DIFF
--- a/src/js/components/communities/scenes/community/components/community-header/CommunityHeader.js
+++ b/src/js/components/communities/scenes/community/components/community-header/CommunityHeader.js
@@ -163,15 +163,17 @@ const CommunityHeader = ({
             <Link to={`/communities/${community.id}`}>Team</Link>
           </Nav.Item>
 
-          <Nav.Item>
-            <Button.Link inverted to={`/communities/${community.id}/events/new`} activeClassName="hidden">
-              <span className="hidden-lg">
-                <Icon name="plus" />
-                <Icon name="handshake outline" />
-              </span>
-              <span className="hidden-md hidden-xs">Create an event</span>
-            </Button.Link>
-          </Nav.Item>
+          {(community.is_owner || community.is_admin) &&
+            <Nav.Item>
+              <Button.Link to={`/communities/${community.id}/events/new`} activeClassName="hidden">
+                <span className="hidden-lg">
+                  <Icon name="plus" />
+                  <Icon name="handshake outline" />
+                </span>
+                <span className="hidden-md hidden-xs">Create an event</span>
+              </Button.Link>
+            </Nav.Item>
+          }
         </Nav>
       </div>
     </div>

--- a/src/js/components/communities/scenes/community/components/community-header/__snapshots__/CommunityHeader.spec.js.snap
+++ b/src/js/components/communities/scenes/community/components/community-header/__snapshots__/CommunityHeader.spec.js.snap
@@ -44,31 +44,6 @@ exports[`CommunityHeader should render correctly 1`] = `
             Team
           </Link>
         </Component>
-        <Component>
-          <Component
-            activeClassName="hidden"
-            inverted={true}
-            to="/communities/undefined/events/new"
-          >
-            <span
-              className="hidden-lg"
-            >
-              <Icon
-                as="i"
-                name="plus"
-              />
-              <Icon
-                as="i"
-                name="handshake outline"
-              />
-            </span>
-            <span
-              className="hidden-md hidden-xs"
-            >
-              Create an event
-            </span>
-          </Component>
-        </Component>
       </Nav>
     </div>
   </div>

--- a/src/js/components/event-settings/scenes/event-update/EventUpdateContainer.js
+++ b/src/js/components/event-settings/scenes/event-update/EventUpdateContainer.js
@@ -18,7 +18,8 @@ class EventUpdateContainer extends Component {
   }
 
   handleSubmit = () => {
-    return this.props.updateEvent(this.state.event).then(event => this.setState({event}))
+    return this.props.updateEvent(this.state.event)
+                     .then(event => this.setState({event}))
   }
 
   getProps = () => ({

--- a/src/js/components/event-settings/scenes/event-update/EventUpdateContainer.js
+++ b/src/js/components/event-settings/scenes/event-update/EventUpdateContainer.js
@@ -4,15 +4,28 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
 class EventUpdateContainer extends Component {
+  state = { event: {} }
+
+  componentWillMount() {
+    this.setState({event: this.props.event})
+  }
 
   handleChange = (e) => {
-    this.props.handleChange(e.target.name, e.target.value)
+    this.setState({event: {
+      ...this.state.event,
+      [e.target.name]: e.target.value
+    }})
+  }
+
+  handleSubmit = () => {
+    return this.props.updateEvent(this.state.event).then(event => this.setState({event}))
   }
 
   getProps = () => ({
     ...this.props,
     ...this.state,
     handleChange: this.handleChange,
+    handleSubmit: this.handleSubmit,
   })
 
   render () {

--- a/src/js/components/events/reducers/event-reducer.js
+++ b/src/js/components/events/reducers/event-reducer.js
@@ -8,7 +8,7 @@ const eventReducer = (state=initialState.event, action) => {
     case actionTypes.EVENT_CREATE_START:
     case actionTypes.EVENT_SHOW_START:
     case actionTypes.EVENT_UPDATE_START:
-      return {loading: true}
+      return {...state, loading: true}
 
     case actionTypes.EVENT_CREATE_COMPLETE:
     case actionTypes.EVENT_SHOW_COMPLETE:
@@ -18,7 +18,7 @@ const eventReducer = (state=initialState.event, action) => {
     case actionTypes.EVENT_CREATE_FAIL:
     case actionTypes.EVENT_SHOW_FAIL:
     case actionTypes.EVENT_UPDATE_FAIL:
-      return {error: true}
+      return {...state, loading: false, error: true}
 
     case actionTypes.EVENT_ATTEND_CREATE_COMPLETE:
       return {...state, ...action.payload}

--- a/src/js/components/events/scenes/event/EventContainer.js
+++ b/src/js/components/events/scenes/event/EventContainer.js
@@ -7,7 +7,6 @@ import Auth from 'js/auth'
 
 import {
   getCommunitiesSuggestions,
-  mockGetCommunities
 } from 'js/components/communities/actions'
 
 import {

--- a/src/js/components/shared/sidebar/Sidebar.js
+++ b/src/js/components/shared/sidebar/Sidebar.js
@@ -14,7 +14,7 @@ const StyledSidebar = styled.div`
   background: ${lighten(-0.15, colors.blue)};
   
   p {
-    color: ${colors.white};
+    color: ${lighten(0.4, colors.blue)};
   }
   
   ${


### PR DESCRIPTION
This PR:
* Fixes issue with event update from the backstage.
* Hides the `create event` button when Charles is neither an owner of a community or one of the organizers.